### PR TITLE
use 7.3 preview version not need customized webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.0",
-    "dynamsoft-javascript-barcode": "^7.1.3",
+    "keillion-dynamsoft-javascript-barcode": "0.20200110.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-load-script": "0.0.6",

--- a/src/Dynamsoft.js
+++ b/src/Dynamsoft.js
@@ -1,5 +1,5 @@
-import Dynamsoft from "dynamsoft-javascript-barcode";
-Dynamsoft.BarcodeReader.engineResourcePath = "https://cdn.jsdelivr.net/npm/dynamsoft-javascript-barcode@7.2.3-v2/dist/";
+import Dynamsoft from "keillion-dynamsoft-javascript-barcode";
+Dynamsoft.BarcodeReader.engineResourcePath = "https://cdn.jsdelivr.net/npm/keillion-dynamsoft-javascript-barcode@0.20200110.0/dist/";// 0.20200110.0 is preview for dbrjs 7.3.0-v0
 // Please visit https://www.dynamsoft.com/CustomerPortal/Portal/TrialLicense.aspx to get a trial license
 Dynamsoft.BarcodeReader.productKeys = "t0068NQAAAHFz8G3olEbtsZE7lyhTmeygjYMnxO53Su7Q40dqsDBhVOctKSaRO5tBc1axC5je0Sg3jXZIqSufQKfXoPzzyPc=";
 // Dynamsoft.BarcodeReader._bUseFullFeature = true; // Control of loading min wasm or full wasm.


### PR DESCRIPTION
Because we customized the webpack.config.js to let webpack not import the shadow nodejs environment and not build dependence need by node.
so need react-app-rewired load the additional [config-overrides.js](https://github.com/dynamsoft-dbr/javascript-barcode/blob/master/example/web/react/config-overrides.js)

dbrjs 7.3 will not need it. we find a new way to define how dbrjs work correctly without config on webpack/rollup.
Still work both on web and node.